### PR TITLE
fix: get dnf vars for alternative EL distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,21 @@
 
 The community yum.sh collector did not include a separate metric for updates with security advisories. This does, as well as leverages dnf's python library directly.
 
-This has been tested on RHEL9 and Fedora 38.
+This has been tested on:
+* RHEL9
+* CentOS Stream 9
+* AlmaLinux 8/9
+* RockyLinux 8/9
+* Fedora 38-40
 
+Enterprise Linux variants (everything here except Fedora) [need EPEL configured](https://docs.fedoraproject.org/en-US/epel/).
+
+Depends on the Prometheus client library and is tested with the EPEL/Fedora provided versions for all aforementioned distros.
+```
+# dnf install python3-prometheus_client
+```
+
+Help:
 ```
 % ./dnf_collector.py -h
 usage: dnf_collector.py [-h] [-o FILENAME]

--- a/dnf_collector.py
+++ b/dnf_collector.py
@@ -10,6 +10,7 @@ parser.add_argument(
     metavar="FILENAME",
     help="Optional output file to use rather than standard output.",
 )
+
 args = parser.parse_args()
 
 namespace = "dnf"
@@ -32,7 +33,13 @@ metrics = {
     ),
 }
 base = dnf.Base()
+base.conf.substitutions.update_from_etc("/")
 base.read_all_repos()
+
+for repo in base.repos.iter_enabled():
+    metrics["upgrades_pending"].labels(repo.id).set(0)
+    metrics["security_upgrades_pending"].labels(repo.id).set(0)
+
 base.fill_sack()
 q = base.sack.query()
 q_up = q.upgrades().filter(latest=1)


### PR DESCRIPTION
This populates the dnf vars so metalinks on centos, rocky and alma won't throw 404s.

It also initializes metrics for enabled repos to 0 so alert rules can resolve faster instead of relying on null.